### PR TITLE
don't add backslashes to tag on transform format

### DIFF
--- a/Plus1Minus1Plugin.php
+++ b/Plus1Minus1Plugin.php
@@ -153,7 +153,7 @@ class Plus1Minus1Plugin extends StudipPlugin implements SystemPlugin
 
     static function transformMarkupPlus1Minus1($markup, $matches, $contents)
     {
-        return "\[".$matches[1].":".md5(uniqid("Plus1Minus1Plugin::transformMarkupPlus1Minus1"))."\]";
+        return "[".$matches[1].":".md5(uniqid("Plus1Minus1Plugin::transformMarkupPlus1Minus1"))."]";
     }
 
     static function markupPlus1Minus1($markup, $matches, $contents)


### PR DESCRIPTION
adding backslashes breaks the `[+1-1]` or `[+1]` tag upon the first save. e.g. `[+1]` is transformed to

```
\[+1:f87d7cdfc2b7463415e72106d80c4899\]
```

but should really be transformed to

```
[+1:f87d7cdfc2b7463415e72106d80c4899]
```
