### PR TITLE
replace deprecated jQuery function .live() with .on() to ensure compatibility

### DIFF
--- a/plugin.manifest
+++ b/plugin.manifest
@@ -1,8 +1,8 @@
 pluginclassname=Plus1Minus1Plugin
 pluginname=Plus1Minus1Plugin
-studipminversion=2.0
 origin=tobiasthelen
-version=0.2.0
+version=0.2.2
 description="Embeddable +1/-1 voting via Stud.IP markup."
+studipMinVersion=3.0
 dbscheme=db/install.sql
 uninstalldbscheme=db/uninstall.sql

--- a/templates/vote_click.php
+++ b/templates/vote_click.php
@@ -1,11 +1,11 @@
-jQuery(function() {
-     jQuery('a.plus1minus1vote').live('click', function () {
+(function ($) {
+     $(document).on('click', 'a.plus1minus1vote', function () {
           $(this).parent().load(
               '<?= PluginEngine::getURL('Plus1Minus1Plugin/vote') ?>',
               { vote_id: $(this).attr('data-voteid'), vote: $(this).attr('data-vote'), markup: $(this).attr('data-markup') });
           return false;
       });
 
-      // jQuery('#plus1minus1listvotes img[title]').tooltip();
-});
+      // $('#plus1minus1listvotes img[title]').tooltip();
+}(jQuery));
 


### PR DESCRIPTION
Da das verwendete .live() in jQuery seit Version 1.9 entfernt wurde, und Stud.IP mit Version 3.4 ein Update auf jQuery 1.11 bekommt, ist diese Anpassung notwendig, damit das Plugin weiterhin funktioniert.
